### PR TITLE
Fix mouse moves upscaling

### DIFF
--- a/domains.c
+++ b/domains.c
@@ -709,8 +709,8 @@ static void domain_calculate_abs_scaling(const char *path, void *opaque)
     if (d == NULL || path == NULL)
         return;
 
-    d->rel_x_mult = REL_MULT;
-    d->rel_y_mult = REL_MULT;
+    d->rel_x_mult = MAX_MOUSE_ABS_X / DEFAULT_RESOLUTION_X;
+    d->rel_y_mult = MAX_MOUSE_ABS_Y / DEFAULT_RESOLUTION_Y;
 
     buff = xenstore_read(path);
     if (!buff || strlen(buff) == 0)
@@ -734,8 +734,8 @@ static void domain_calculate_abs_scaling(const char *path, void *opaque)
     info("Found valid desktopDimensions node for domain %d, xres is %d, yres is %d", d->domid, xres, yres);
     free(buff);
 
-    d->rel_x_mult = (double) MOUSE_REL_MULT_DIVIDEND / (double) xres;
-    d->rel_y_mult = (double) MOUSE_REL_MULT_DIVIDEND / (double) yres;
+    d->rel_x_mult = (double) MAX_MOUSE_ABS_X / (double) xres;
+    d->rel_y_mult = (double) MAX_MOUSE_ABS_Y / (double) yres;
 
     /* If the desktop dimensions have changed, need to adjust the mouse position. */
     input_domain_handle_resolution_change(d, xres, yres);
@@ -801,7 +801,8 @@ static void switcher_domid(struct domain *d, uint32_t domid)
           warning("failed to install xenstore watch! switcher/command");
 
 
-  d->rel_x_mult = d->rel_y_mult = REL_MULT;
+  d->rel_x_mult = MAX_MOUSE_ABS_X / DEFAULT_RESOLUTION_X;
+  d->rel_y_mult = MAX_MOUSE_ABS_Y / DEFAULT_RESOLUTION_Y;
   d->desktop_xres = d->desktop_yres = 0;
   if (!xenstore_dom_watch(d->domid, domain_calculate_abs_scaling, d, "attr/desktopDimensions"))
           warning("failed to install xenstore watch! attr/desktopDimensions");

--- a/input.c
+++ b/input.c
@@ -1335,8 +1335,8 @@ static void compute_mouse_speed(void)
 {
     const double default_speed = 1.5;
     const double increment = 0.25;
-    double mult_threshold_1 = (double) MOUSE_DIV_THRESHOLD_1 / (double) MOUSE_REL_MULT_DIVIDEND;
-    double mult_threshold_2 = (double) MOUSE_DIV_THRESHOLD_2 / (double) MOUSE_REL_MULT_DIVIDEND;
+    double mult_threshold_1 = (double) MOUSE_DIV_THRESHOLD_1 / (double) MAX_MOUSE_ABS_X;
+    double mult_threshold_2 = (double) MOUSE_DIV_THRESHOLD_2 / (double) MAX_MOUSE_ABS_Y;
     int config_speed = input_get_mouse_speed();
 
     mouse_speed = default_speed - ((DEFAULT_CONFIG_MOUSE_SPEED - config_speed) * increment);
@@ -1452,6 +1452,18 @@ static double get_mouse_speed_mult(struct input_event *e, enum input_device_type
 
 static void input_track_mouse_position(struct input_event *e, enum input_device_type input_type)
 {
+    int xres, yres;
+
+    if (mouse_dest->desktop_xres == 0)
+      xres = DEFAULT_RESOLUTION_X;
+    else
+      xres = mouse_dest->desktop_xres;
+
+    if (mouse_dest->desktop_yres == 0)
+      yres = DEFAULT_RESOLUTION_Y;
+    else
+      yres = mouse_dest->desktop_yres;
+
     /* Don't track mouse position if mouse_dest is NULL. */
     if (e->type == EV_REL && mouse_dest != NULL)
     {
@@ -1459,7 +1471,7 @@ static void input_track_mouse_position(struct input_event *e, enum input_device_
         {
         case REL_X:
             if (input_type == HID_TYPE_TOUCHPAD)
-                mouse_x += e->value * REL_MULT;
+                mouse_x += e->value * (MAX_MOUSE_ABS_X / xres);
             else
                 mouse_x += e->value * mouse_dest->rel_x_mult * get_mouse_speed_mult(e, input_type);
 
@@ -1467,7 +1479,7 @@ static void input_track_mouse_position(struct input_event *e, enum input_device_
             break;
         case REL_Y:
             if (input_type == HID_TYPE_TOUCHPAD)
-                mouse_y += e->value * REL_MULT;
+                mouse_y += e->value * (MAX_MOUSE_ABS_Y / yres);
             else
                 mouse_y += e->value * mouse_dest->rel_y_mult * get_mouse_speed_mult(e, input_type);
 

--- a/project.h
+++ b/project.h
@@ -112,12 +112,9 @@
 #define MIN_MOUSE_ABS_Y 0
 #define MAX_MOUSE_ABS_Y 0x7fff
 
-/* Default multiplier used for converting relative events to absolute. */
-#define REL_MULT 50
-
-/* A number to divide the resolutions by, so that we get a decent default mouse
-   speed when converting relative events to absolute. */
-#define MOUSE_REL_MULT_DIVIDEND 30000
+/* The default resolution to use when the VM doesn't report any */
+#define DEFAULT_RESOLUTION_X	1920
+#define DEFAULT_RESOLUTION_Y	1080
 
 /* A dividend at which pixel precision works well when converting relative
    events to absolute. We have two thresholds, one for slow moves, the other


### PR DESCRIPTION
MOUSE_REL_MULT_DIVIDEND (30000) and REL_MULT (50) seem to be approximates for up-scaling the mouse moves to the size of the absolute input device that gets exposed to the guests.

REL_MULT_DIVIDENT was used as the absolute input size, instead of MAX_MOUSE_ABS_[X,Y]
REL_MULT was used as a multiplier, instead of [size of the absolute mouse] divided by [resolution]

I tested that fix, along with a workaround for win-tools (see https://github.com/OpenXT/win-tools/pull/1), and got very smooth mouse movements in a 4-monitors-wide configuration.

The only thing I'm not completely sure about is the MOUSE_DIV_THRESHOLD thing for mouse speed. I can remove that part of the commit if requested.
