### PR TITLE
demultitouch: defer up-clicks. vkbd:send clicks to the absolute device.

### DIFF
--- a/xen_event.c
+++ b/xen_event.c
@@ -48,7 +48,11 @@ xen_event_send_key(struct xen_vkbd_backend *backend, bool down, int keycode)
     event.key.pressed = down ? 1 : 0;
     event.key.keycode = keycode;
 
-    return xen_event_write_page(backend->abs_device, &event);
+    if (keycode >= BTN_LEFT && keycode <= BTN_TASK)
+        /* This is a mouse click, sending to the absolute device. */
+        return xen_event_write_page(backend->abs_device, &event);
+    else
+        return xen_event_write_page(backend->device, &event);
 }
 
 /* Send a relative mouse movement */

--- a/xen_event.c
+++ b/xen_event.c
@@ -48,7 +48,7 @@ xen_event_send_key(struct xen_vkbd_backend *backend, bool down, int keycode)
     event.key.pressed = down ? 1 : 0;
     event.key.keycode = keycode;
 
-    return xen_event_write_page(backend->device, &event);
+    return xen_event_write_page(backend->abs_device, &event);
 }
 
 /* Send a relative mouse movement */


### PR DESCRIPTION
- We need to make sure we sent and sync-ed the last coordinates before up-clicking, just like down-clicking.
- Moves and clics have to be sent through the same device, especially for touch events.  
    Defaulting to the absolute device instead of the relative one, as events seem to always be absolute.  
    If this is incorrect, we should introduce some device_currently_in_use global variable.

Signed-off-by: Jed <lejosnej@ainfosec.com>