### PR TITLE
Use DBus instead of dmbus to attach/detach Vkbd to a PV guest.

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -38,7 +38,7 @@ DBUS_SERVER_IDLS=input_daemon
 
 SRCS=server.c bus.c secure_scripts.c user.c secure.c input.c domains.c \
      switch.c util.c focus.c touchpad.c keymap.c usb-tablet.c rpcgen/input_daemon_server_obj.c \
-     pm.c xen_vkbd.c xen_event.c gesture.c lid.c encapsulate.c socket.c
+     pm.c xen_vkbd.c xen_event.c gesture.c lid.c encapsulate.c socket.c debug.c
 
 LIBS=-lz -lssl -levent @UDEV_LIBS@ @DBUS_LIBS@ @DBUS_GLIB_LIBS@ @LIBXCDBUS_LIBS@ @LIBXC_LIB@ @LIBXCXENSTORE_LIBS@ @LIBDMBUS_LIB@ @LIBV4V_LIB@ @LIBXENBACKEND_LIB@
 

--- a/bus.c
+++ b/bus.c
@@ -30,12 +30,14 @@ static const char NoSrcId[]   = "NoSrcUuid";
 static const char Busy[]      = "Busy";
 static const char BadFrame[]      = "BadFrame";
 static const char OutOfRange[]      = "OutOfRange";
-static const char FailedVkbd[] = "FailedVkbd";
+static const char FailVkbdAttach[] = "FailVkbdAttach";
+static const char FailVkbdDetach[] = "FailVkbdDetach";
 
 static const char BadUuid_txt[]   = "The UUID '%s' could not be found.";
 static const char NoMemory_divert_txt[] = "Could not create divert info.";
 static const char NoSrcId_txt[] = "The UUID of the caller could not be found.  (This method cannot be called from Dom0!)";
-static const char FailedVkbd_txt[] = "Failed to create a Vkbd input domain.";
+static const char FailVkbdAttach_txt[] = "Could not attach Vkbd to dom%u.";
+static const char FailVkbdDetach_txt[] = "Could not detach Vkbd from dom%u.";
 
 gboolean
 input_daemon_set_slot(InputDaemonObject *this, gint IN_domid, gint IN_slot, GError** err)
@@ -280,9 +282,11 @@ input_daemon_switch_focus (InputDaemonObject *this, gint IN_domid, gboolean IN_f
 
     dom = domain_with_domid(IN_domid);
     if (!dom) {
+        warning("Cannot switch to dom%u, this domid is not registered.", IN_domid);
         goto out;
     }
     if (switcher_switch(dom, 0, IN_force) < 0) {
+        warning("Cannot switch to dom%u, switcher_switch() failed...", IN_domid);
         goto out;
     }
     // hooray
@@ -953,19 +957,53 @@ input_daemon_property_set_numlock_restore_on_switch(InputDaemonObject *this, gbo
 }
 
 gboolean
-input_daemon_connect_vkbd(InputDaemonObject *this, gint IN_domid, GError** err)
+input_daemon_attach_vkbd(InputDaemonObject *this, gint IN_domid, GError **err)
 {
     struct domain *d;
 
-    info("%s(): dom%u", __func__, IN_domid);
-    d = domain_connect_vkbd(IN_domid);
-    /* TODO: manage PTR_ERR(errno) to return a precise failure.*/
+
+    d = domain_with_domid(IN_domid);
     if (d == NULL) {
-        set_error(err, gI, FailedVkbd, FailedVkbd_txt);
+        d = domain_new(IN_domid);
+        if (d == NULL)
+            goto fail;
+        if (domain_setup(d))
+            goto fail_and_free_domain;
+        if (domain_set_pvm(d, false))
+            goto fail_and_free_domain;
+    }
+    if (domain_attach_vkbd(d))
+        return FALSE;
+
+    /* Update the slots[] global with what we just configured for this domain.
+     * This will send input to the vkbd frontend with little sanity checks.
+     * XXX: This is a tad convoluted.
+     */
+    focus_update_domain(d);
+
+    return TRUE;
+
+fail_and_free_domain:
+    domain_release(d);
+fail:
+    set_error(err, gI, FailVkbdAttach, FailVkbdAttach_txt, IN_domid);
+    return FALSE;
+}
+
+
+gboolean
+input_daemon_detach_vkbd(InputDaemonObject *this, gint IN_domid, GError** err)
+{
+    struct domain *d;
+
+    d = domain_with_domid(IN_domid);
+    if (d == NULL) {
+        warning("%s: Could not detach VKBD from dom%u. Dom%u does not exist.",
+                __func__, IN_domid, IN_domid);
+        set_error(err, gI, FailVkbdDetach, FailVkbdDetach_txt, IN_domid);
         return FALSE;
     }
-    // XXX: Was always set to true by dmbus (the switcher_abs was always sent). Lets save an RPC.
-    d->abs_enabled = true;
+    domain_detach_vkbd(d);
 
     return TRUE;
 }

--- a/input.c
+++ b/input.c
@@ -619,7 +619,7 @@ static void input_send(struct domain *d, int slot, struct input_event *e)
     }
 
 #ifdef debug_packets
-    debug_packet(slot, e);
+    if (e) debug_packet(slot, e);
 #endif
 
     inputevent_action ia;

--- a/main.c
+++ b/main.c
@@ -26,7 +26,7 @@ int     main(int argc,char *argv[])
     bus_init();
     xenstore_init();
     input_init();
-    domain_init();
+    domains_init();
     server_init();
 
     switcher_init();

--- a/project.h
+++ b/project.h
@@ -131,4 +131,7 @@ enum input_device_type
     HID_TYPE_THINKPAD_ACPI
 };
 
+//#define debug 1
+//#define debug_packets 1
+
 #include "prototypes.h"

--- a/prototypes.h
+++ b/prototypes.h
@@ -162,6 +162,8 @@ void input_release(_Bool in_fork);
 int input_init(void);
 void sock_plugin_sendconfig(struct sock_plugin* plug);
 /* domains.c */
+void domain_print(const struct domain *d);
+void domains_print(void);
 void iterate_domains(void (*callback)(struct domain *, void *), void *opaque);
 void check_diverts_for_the_dead(struct domain *d);
 int domains_count(void);
@@ -185,8 +187,17 @@ void domain_wake_from_s3(struct domain *d);
 void domain_mouse_switch_config(void *opaque);
 struct domain *domain_create(dmbus_client_t client, int domid, DeviceType type);
 struct domain *domain_connect_vkbd(int domid);
-void domain_init(void);
-void domain_release(_Bool infork);
+void domains_init(void);
+void domains_release(_Bool infork);
+
+void domain_init(struct domain *d, int domid);
+struct domain *domain_new(int domid);
+void domain_release(struct domain *d);
+int domain_assign_slot(struct domain *d);
+int domain_setup(struct domain *d);
+int domain_set_pvm(struct domain *d, bool is_pvm);
+int domain_attach_vkbd(struct domain *d);
+void domain_detach_vkbd(struct domain *d);
 /* switch.c */
 int switcher_switch_graphic(struct domain *d, int force);
 void switcher_unfocus_gpu(void);

--- a/prototypes.h
+++ b/prototypes.h
@@ -184,6 +184,7 @@ void handle_switcher_shutdown(void *priv, struct msg_switcher_shutdown *msg, siz
 void domain_wake_from_s3(struct domain *d);
 void domain_mouse_switch_config(void *opaque);
 struct domain *domain_create(dmbus_client_t client, int domid, DeviceType type);
+struct domain *domain_connect_vkbd(int domid);
 void domain_init(void);
 void domain_release(_Bool infork);
 /* switch.c */

--- a/switch.h
+++ b/switch.h
@@ -37,6 +37,7 @@ struct divert_info_t;
 
 struct domain
 {
+    bool                    initialised;
     dmbus_client_t          client;
     int                     domid;
     int                     slot;

--- a/xen_vkbd.c
+++ b/xen_vkbd.c
@@ -182,6 +182,7 @@ xen_vkbd_backend_create(struct domain *d)
     backend->backend = backend_register("vkbd", d->domid, &xen_vkbd_backend_ops, backend);
     if (!backend->backend)
     {
+	error("%s: failed to register VKBD backend for dom%u!", __func__, d->domid);
         free(backend);
         return;
     }


### PR DESCRIPTION
Still keep the dmbus compatibility for now, this is further work to be done with the Libxl toolstack integration.

OXT-544