### PR TITLE
PV guest do not have dmbus connection

### DIFF
--- a/domains.c
+++ b/domains.c
@@ -1015,7 +1015,8 @@ void handle_switcher_shutdown(void *priv, struct msg_switcher_shutdown *msg, siz
 static void send_wakeup(struct domain *d)
 {
     struct msg_input_wakeup msg;
-    input_wakeup(d->client, &msg, sizeof(msg));
+    if (d->client)
+        input_wakeup(d->client, &msg, sizeof(msg));
 }
 
 void domain_wake_from_s3(struct domain *d)

--- a/input.c
+++ b/input.c
@@ -333,7 +333,8 @@ static void send_config_reset(struct domain *d, uint8_t slot)
 {
     struct msg_input_config_reset msg;
     msg.slot = slot;
-    input_config_reset(d->client, &msg, sizeof(msg));
+    if (d->client)
+        input_config_reset(d->client, &msg, sizeof(msg));
 
     if (d->plugin)
        send_plugin_dev_event(d->plugin, DEV_RESET, slot); 


### PR DESCRIPTION
dmbus client handler was used to test for domain initialisation prior
OXT-544, this is no longer the case since PV-guest will set up vkbd
directly without talking to dm-agent.
Assumption was /client/ field in the /struct domains/ was always a valid
pointer for an initialized domains, but this is no longer the case.

OXT-570