### PR TITLE
OXT-1001: Input pointing devices detection

### DIFF
--- a/input.c
+++ b/input.c
@@ -2702,49 +2702,46 @@ static int find_pointer_device_type(int fd, unsigned int bustype, uint8_t * subt
     memset(abslimits, 0, sizeof(abslimits));
     memset(keybits, 0, sizeof(abslimits));
 
-    if ((ret = ioctl(fd, EVIOCGBIT(0, sizeof(eventtypes)), eventtypes)) < 0)
+    ret = ioctl(fd, EVIOCGBIT(0, sizeof (eventtypes)), eventtypes);
+    if (ret < 0)
         return ret;
 
-    /* Check if the device supports absolute events. */
+    /* Handle all EV_REL capable devices as mice.
+     * TODO: This is inacurate, but seems to be good enough for now. */
+    if (TEST_BIT(EV_REL, eventtypes))
+        return HID_TYPE_MOUSE;
+
+    /* No EV_REL and no EV_ABS == this is not a pointing device. */
     if (!TEST_BIT(EV_ABS, eventtypes))
-        return HID_TYPE_MOUSE;
+        return -1;
+    ret = ioctl(fd, EVIOCGBIT(EV_ABS, sizeof (abslimits)), abslimits);
+    if (ret < 0)
+        return -1;
 
-    /* USB mice also support absolute events, so we need to perform
-       additional checks to determine if the device is a touchpad, or tablet. */
-    if (!TEST_BIT(EV_SYN, eventtypes) || !TEST_BIT(EV_KEY, eventtypes))
-        return HID_TYPE_MOUSE;
+    /* Do not recognize pointing devices not having at least X,Y coordinates?
+     * MT devices might report ABS_MT_POSITION?
+     * What about other coordinates? */
+    if (!TEST_BIT(ABS_X, abslimits) || !TEST_BIT(ABS_Y, abslimits))
+        return -1;
 
-    if ((ret = ioctl(fd, EVIOCGBIT(EV_ABS, sizeof(abslimits)), abslimits)) < 0)
-        return ret;
+    /* Assume all touchpads report ABS_PRESSURE and tablet don't. Use it to
+     * detect them from tablets. */
+    if (TEST_BIT(ABS_PRESSURE, abslimits))
+        return HID_TYPE_TOUCHPAD;
 
-    if ((ret = ioctl(fd, EVIOCGBIT(EV_KEY, sizeof(keybits)), keybits)) < 0)
-        return ret;
+    ret = ioctl(fd, EVIOCGBIT(EV_KEY, sizeof (keybits)), keybits);
+    if (ret < 0)
+        return -1;
 
-    if (TEST_BIT(ABS_X, abslimits) && TEST_BIT(ABS_Y, abslimits))
-    {
-/* Touchpads can be USB!  BTN_TOOL_FINGER can be used to tell its a touchpad.  However, by correctly 
-identifying that the wacom bamboo touchpad is a touchpad, it stops it working.  So for now its better to work wrongly */
+    /* From there, this device is considered a tablet.
+     * Assume PEN or FINGER will be enough to have discrepancy between tablet
+     * sub-types. */
+    if (TEST_BIT(BTN_TOOL_PEN, keybits))
+        *subtype = SUBTYPE_STYLUS;
+    if (TEST_BIT(BTN_TOOL_FINGER, keybits))
+        *subtype = SUBTYPE_MONOTOUCH;
 
-/*        if (((bustype == BUS_I8042) || (TEST_BIT(BTN_TOOL_FINGER, keybits))) && */
-        if (((bustype == BUS_I8042)) && (TEST_BIT(ABS_PRESSURE, abslimits)))
-            return HID_TYPE_TOUCHPAD;
-
-        if ((bustype == BUS_USB) || (bustype == BUS_RS232) || bustype == BUS_I2C)
-        {
-            if (TEST_BIT(BTN_TOOL_PEN, keybits))
-            {
-                *subtype = SUBTYPE_STYLUS;
-            }
-            if (TEST_BIT(BTN_TOOL_FINGER, keybits))
-            {
-                *subtype = SUBTYPE_MONOTOUCH;
-            }
-        }
-
-        return HID_TYPE_TABLET;
-    }
-
-    return HID_TYPE_MOUSE;
+    return HID_TYPE_TABLET;
 }
 
 static int device_is_thinkpad_acpi(unsigned int bustype, const char *name)

--- a/project.h
+++ b/project.h
@@ -97,6 +97,7 @@
 #define OFF(x)   ((x) % LONG_BITS)
 #define LONG(x)  ((x) / LONG_BITS)
 #define TEST_BIT(bit, array) (array[LONG(bit)] & (1 << OFF(bit)))
+#define ARRAY_LEN(arr) (sizeof (arr) / sizeof ((arr)[0]))
 
 #define BTN_WORDS 3
 #define ABS_WORDS 2


### PR DESCRIPTION
The existing code did not detect present devices correctly and used to consider input "ACPI Video bus" on i2c as a mouse.