### PR TITLE
OXT-675: Handle touchpads without ABS_PRESSURE capability.

### DIFF
--- a/input.c
+++ b/input.c
@@ -2724,14 +2724,19 @@ static int find_pointer_device_type(int fd, unsigned int bustype, uint8_t * subt
     if (!TEST_BIT(ABS_X, abslimits) || !TEST_BIT(ABS_Y, abslimits))
         return -1;
 
-    /* Assume all touchpads report ABS_PRESSURE and tablet don't. Use it to
-     * detect them from tablets. */
+    /* Some touchpads report ABS_PRESSURE, but tablet don't appear to... */
     if (TEST_BIT(ABS_PRESSURE, abslimits))
         return HID_TYPE_TOUCHPAD;
 
     ret = ioctl(fd, EVIOCGBIT(EV_KEY, sizeof (keybits)), keybits);
     if (ret < 0)
         return -1;
+
+    /* ... when they don't, legacy used to consider BTN_TOUCH &
+     * BTN_TOOL_FINGER as touchpads.  This should be good enough since there is
+     * no "touch-screen" type in input-server yet. */
+    if (TEST_BIT(BTN_TOOL_FINGER, keybits) && TEST_BIT(BTN_TOUCH, keybits))
+        return HID_TYPE_TOUCHPAD;
 
     /* From there, this device is considered a tablet.
      * Assume PEN or FINGER will be enough to have discrepancy between tablet

--- a/touchpad.c
+++ b/touchpad.c
@@ -64,6 +64,7 @@ struct touchpad_packet
     int y;                    /* X position of finger. */
     int pressure;             /* Finger pressure. */
     int button_mask;          /* Left or right button click. */
+    int btn_touch;            /* Value for BTN_TOUCH reporting contact. */
     struct timeval timestamp;
     int fingertouching;
 };
@@ -234,22 +235,27 @@ static enum edge_type detect_edge(int x, int y, int right_edge, int bottom_edge,
     return etype;
 }
 
-static int detect_finger(int pressure, struct touchpad_limits *tl)
+static int detect_finger(const struct touchpad_packet *tp, const struct touchpad_limits *tl)
 {
     static int fingertouching = 0;
     int range = tl->max_pressure - tl->min_pressure;
 
-    if (pressure == tl->no_pressure)
+    if (!range) {
+        fingertouching = tp->btn_touch;
+        return fingertouching;
+    }
+
+    if (tp->pressure == tl->no_pressure)
         return fingertouching;
 
     if (!fingertouching)
     {
-        if (pressure > (tl->min_pressure + (range * PRESSURE_UP_MULT)))
+        if (tp->pressure > (tl->min_pressure + (range * PRESSURE_UP_MULT)))
             fingertouching = 1;
     }
     else
     {
-        if (pressure < (tl->min_pressure + (range * PRESSURE_DOWN_MULT)))
+        if (tp->pressure < (tl->min_pressure + (range * PRESSURE_DOWN_MULT)))
             fingertouching = 0;
     }
 
@@ -975,7 +981,7 @@ static void process_packet(struct touchpad_state *ts,
 
     edge = detect_edge(x_value, y_value, tl->right_edge, tl->bottom_edge, tl->top_edge);
 
-    tp->fingertouching = detect_finger(tp->pressure, tl);
+    tp->fingertouching = detect_finger(tp, tl);
 
     if (tl->is_clickpad)
         handle_clickpad(ts, tp, tl, edge);
@@ -1030,12 +1036,13 @@ void handle_touchpad_event(struct input_event *ev,int slot)
     }
     else if (ev->type == EV_KEY)
     {
-     
         if ((ev->code >=BTN_LEFT) && (ev->code <=BTN_TASK))
-        {       
+        {
             int bitpair = (ev->code - BTN_LEFT) << 1;
             tpacket.button_mask |= 1 << ( bitpair + (ev->value?0:1));
         }
+        if (ev->code == BTN_TOUCH)
+            tpacket.btn_touch = ev->value;
     }
 }
 


### PR DESCRIPTION
Input server will detect as a tablet a touchpad that do not have ABS_PRESSURE. Dell E7450 is packaged with Alps Dualpoint touchpad that do not have that capability. So ```input_server``` will handle it as a tablet (absolute coordinates, no touch-click detection).

This PR change the detection to have the expected behavior for a touchpad and add support to detect finger touch without relying on ABS_PRESSURE.