### PR TITLE
Attend potential bugs and code sanity.

### DIFF
--- a/domains.c
+++ b/domains.c
@@ -305,7 +305,7 @@ static void
 domain_active_adapter_watch(const char *path, void *opaque)
 {
     struct domain *d = opaque;
-    char *buff = NULL, *endptr, node_name[32];
+    char *buff = NULL, *endptr, node_name[33];
     long int val = 0;
     int i;
 

--- a/input.c
+++ b/input.c
@@ -293,8 +293,8 @@ static inputevent_action demultitouch(struct input_event *e)
 
                     return discared_event;
                 }
-                break;
             }
+            break;
         case ABS_MT_SLOT:
             slot = e->value;
 
@@ -309,6 +309,7 @@ static inputevent_action demultitouch(struct input_event *e)
                 }
                 return discared_event;
             }
+            break;
         case ABS_MT_TOUCH_MAJOR:
         case ABS_MT_TOUCH_MINOR:
         case ABS_MT_WIDTH_MAJOR:


### PR DESCRIPTION
New versions of GCC (7.x) reveal interesting warnings:
- Potential overflow in `sprintf()` statement;
- Presumably undesired fall-through in switch-case statement.