### PR TITLE
input: Libevent 2.x changes.

### DIFF
--- a/input.c
+++ b/input.c
@@ -2446,7 +2446,7 @@ static void input_lock_timer(void *opaque)
     static int timeout = 0;
     struct timeval tv = { 0, 0 };
 
-    if (lock_event.ev_flags == 0)
+    if (!event_initialized(&lock_event))
         event_set(&lock_event, -1, EV_TIMEOUT | EV_PERSIST, wrapper_input_lock_timer, (void *) 1);
 
     if ((int) opaque == 0)
@@ -2623,11 +2623,6 @@ int input_secure(int onoff)
                 if (ctx && ctx->flags & AUTH_FLAG_LOCK)
                 {
                     event_set(&revert_to_auth_event, -1, EV_TIMEOUT | EV_PERSIST, wrapper_revert_to_auth, NULL);
-
-                    if (revert_to_auth_event.ev_flags == 0)
-                    {
-                        return 0;
-                    }
                     tv.tv_sec += 1;
                     evtimer_add(&revert_to_auth_event, &tv);
                 }


### PR DESCRIPTION
ev_flags is deprecated in later versions of libevent. Libevent provides event_initialized() to differenciate between initiliazed structure or zero'd memory.