### PR TITLE
RFC: OXT-1709: Refactor and attend warnings with GCC9.

### DIFF
--- a/domains.c
+++ b/domains.c
@@ -228,9 +228,7 @@ domain_get_whitelist_drivers()
               ? (end-beg)
               : (int)strlen(beg);
         if (sz > 0) {
-            driver[dri] = malloc(sz+1);
-            strncpy(driver[dri], beg, sz);
-            driver[dri][sz] = 0;
+            driver[dri] = strndup(beg, sz);
             ++dri;
         }
 

--- a/project.h
+++ b/project.h
@@ -96,7 +96,9 @@
 #define NBITS(x) (((x) + LONG_BITS - 1) / LONG_BITS)
 #define OFF(x)   ((x) % LONG_BITS)
 #define LONG(x)  ((x) / LONG_BITS)
-#define TEST_BIT(bit, array) (array[LONG(bit)] & (1 << OFF(bit)))
+#define TEST_BIT(bit, array) ((array)[LONG(bit)] & (1UL << OFF(bit)))
+#define BIT_SET(bit, array) ((array)[LONG(bit)] |= (1UL << OFF(bit)))
+#define BIT_CLR(bit, array) ((array)[LONG(bit)] &= ~(1UL << OFF(bit)))
 #define ARRAY_LEN(arr) (sizeof (arr) / sizeof ((arr)[0]))
 
 #define BTN_WORDS 3

--- a/secure.c
+++ b/secure.c
@@ -263,8 +263,8 @@ error:
 
 void auth_set_context(const char *user, const char *title, uint32_t flags)
 {
-    strncpy(g_auth_context.user, user, sizeof(g_auth_context.user));
-    strncpy(g_auth_context.title, title, sizeof(g_auth_context.title));
+    memmove(g_auth_context.user, user, sizeof(g_auth_context.user));
+    memmove(g_auth_context.title, title, sizeof(g_auth_context.title));
     g_auth_context.flags = flags;
     info("auth_set_context flags=%u\n", flags);
     g_auth_context_present = 1;

--- a/util.c
+++ b/util.c
@@ -113,15 +113,11 @@ message (int flags, const char *file, const char *function, int line,
         const char *fmt, ...)
 {
     char buf[1024]={0};
-    char *level = NULL;
+    const char *level = "Info";
     va_list ap;
     int len;
 
-    if (flags & MESSAGE_INFO)
-    {
-        level = "Info";
-    }
-    else if (flags & MESSAGE_WARNING)
+    if (flags & MESSAGE_WARNING)
     {
         level = "Warning";
     }


### PR DESCRIPTION
Attend `stringop-truncation` and `format-overflow`.

`-Warray-bound` detects an access out of bounds in keybits, which is accessed through a pointer at an offset in the array. The whole `send_config` function is quite convoluted, it seems to be using the host input event-codes and modifying them accordingly for Xenmou in the guest (Xenmou being the only DM registered to receive DMBus `InputConfig`). This refactoring is an attempt at doing that in a more direct/easy to review way.